### PR TITLE
Replaces deprecated functions and keywords of Matplotlib

### DIFF
--- a/sdf/examples/interp_1d.py
+++ b/sdf/examples/interp_1d.py
@@ -18,14 +18,14 @@ methods = [('hold', 'hold'), ('nearest', 'hold'), ('linear', 'linear'), ('akima'
 
 figure, axes = plt.subplots(len(methods), sharex=True)
 
-figure.canvas.set_window_title('Inter- and Extrapolation Methods')
+figure.canvas.manager.set_window_title('Inter- and Extrapolation Methods')
 figure.set_facecolor('white')
 
 for ax, method in zip(axes, methods):
     yi = table.evaluate((xi,), interp=method[0], extrap=method[1])
     dyi = table.evaluate_derivative((xi,), (dxi,), interp=method[0], extrap=method[1])
     ax.set_title("interp='%s', extrap='%s'" % method)
-    ax.grid(b=True, which='both', color='0.9', linestyle='-', zorder=0)
+    ax.grid(visible=True, which='both', color='0.9', linestyle='-', zorder=0)
     ax.plot(x, y, 'or', label='samples', zorder=300)
     ax.plot(xi, yi, 'b', label='interpolated', zorder=100)
     ax.plot(xi, dyi, 'r', label='derivative', zorder=100)

--- a/sdf/examples/interp_2d.py
+++ b/sdf/examples/interp_2d.py
@@ -21,7 +21,7 @@ xi = yi = np.linspace(-6, 6, 200)
 XI, YI = np.meshgrid(xi, yi, indexing='ij')
 
 figure, axes = plt.subplots(ncols=2, nrows=2, sharex=True, sharey=True)
-figure.canvas.set_window_title('Inter- & Extrapolation Methods')
+figure.canvas.manager.set_window_title('Inter- & Extrapolation Methods')
 figure.set_facecolor('white')
 
 axes = axes.flatten()
@@ -31,7 +31,7 @@ ax.set_title('original')
 im = NonUniformImage(ax)
 im.set_data(x, y, Z)
 im.set_extent((-3, 3, -3, 3))
-ax.images.append(im)
+ax.add_image(im)
 ax.set_xlim([-6, 6])
 ax.set_ylim([-6, 6])
 
@@ -43,7 +43,7 @@ for ax, method in zip(axes[1:], methods):
     im = NonUniformImage(ax)
     im.set_data(xi, yi, ZI)
     im.set_extent((-6, 6, -6, 6))
-    ax.images.append(im)
+    ax.add_image(im)
 
 figure.tight_layout()
 plt.show()

--- a/sdf/examples/spline_1d.py
+++ b/sdf/examples/spline_1d.py
@@ -20,14 +20,14 @@ methods = ['akima', 'fritsch-butland', 'steffen']
 
 figure, axes = plt.subplots(len(methods), sharex=True)
 
-figure.canvas.set_window_title('Spline based interpolation methods')
+figure.canvas.manager.set_window_title('Spline based interpolation methods')
 figure.set_facecolor('white')
 
 for ax, method in zip(axes, methods):
     yi = table.evaluate((xi,), interp=method, extrap='linear')
     dyi = table.evaluate_derivative((xi,), (dxi,), interp=method, extrap='linear')
     ax.set_title(method)
-    ax.grid(b=True, which='both', color='0.9', linestyle='-', zorder=0)
+    ax.grid(visible=True, which='both', color='0.9', linestyle='-', zorder=0)
     ax.plot(x, y, 'or', label='samples', zorder=300)
     ax.plot(xi, yi, 'b', label='interpolated', zorder=100)
     ax.plot(xi, dyi, 'r', label='derivative', zorder=100)

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,4 @@ setup(name='SDF',
                             'linux64/libndtable.so',
                             'darwin64/libNDTable.dylib']},
       platforms=['darwin64', 'linux64', 'win32', 'win64'],
-      install_requires=['numpy', 'h5py', 'matplotlib', 'scipy'])
+      install_requires=['numpy', 'h5py', 'matplotlib>=3.6', 'scipy'])


### PR DESCRIPTION
Hi Torsten,

with Matplotlib 3.6 'canvas.set_window_title' was replaced by 'canvas.manager.set_window_title'.
Also the 'b' keyword of 'ax.grid()' was renamed to 'visible'.

I fixed both in the concerned examples and added a minimum version to the 'install_requires' in the setup.py.

closes #8