### PR TITLE
Replace np.string_ with np._bytes for compatibility with Numpy 2.0

### DIFF
--- a/sdf/hdf5.py
+++ b/sdf/hdf5.py
@@ -150,7 +150,7 @@ def _str(s):
         return s
     else:
         # convert the string to an fixed-length utf-8 byte string
-        return np.string_(s.encode('utf-8'))
+        return np.bytes_(s.encode('utf-8'))
 
 
 def _write_group(f, g, path, datasets):

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,4 @@ setup(name='SDF',
                             'linux64/libndtable.so',
                             'darwin64/libNDTable.dylib']},
       platforms=['darwin64', 'linux64', 'win32', 'win64'],
-      install_requires=['numpy', 'h5py', 'matplotlib', 'scipy'])
+      install_requires=['numpy>=2', 'h5py', 'matplotlib', 'scipy'])


### PR DESCRIPTION
Hi!

In Numpy 2.0 np.string_ was replaced by np.bytes_. To make the SDF example sine.py run, I made this change in sdf/hdf5.py and adjusted the 'install_requires' entry for numpy in setup.py accordingly.

closes #7